### PR TITLE
Discrete Display Dimming

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ use std::{
 
 const DEFAULT_ALPHA: f32 = 0.5;
 const DEFAULT_RADIUS: u32 = 0;
+const INITIAL_ROUNDTRIPS: usize = 10;
 
 static QH: OnceLock<QueueHandle<DimlandData>> = OnceLock::new();
 const IS_DEBUG_BUILD: bool = cfg!(debug_assertions);
@@ -169,10 +170,9 @@ fn main() {
 
   match args.command {
     Some(DimlandCommands::Stop) => {
-      match UnixStream::connect(socket_path) {
-        Ok(mut stream) => stream.write_all("stop".as_bytes()).unwrap(),
-        _ => (),
-      };
+      if let Ok(mut stream) = UnixStream::connect(socket_path) {
+        let _ = stream.write_all("stop".as_bytes());
+      }
       process::exit(0);
     }
     _ => (),
@@ -295,11 +295,8 @@ fn _main() {
   loop {
     event_queue.roundtrip(&mut data).unwrap();
 
-    if i > 10 {
+    if i > INITIAL_ROUNDTRIPS {
       block_until_event();
-      let new_args = get_args();
-      data.alpha = new_args.alpha.unwrap_or(DEFAULT_ALPHA);
-      data.radius = new_args.radius.unwrap_or(DEFAULT_RADIUS);
       data.rerender();
     } else {
       i += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,13 +29,13 @@ use smithay_client_toolkit::{
   },
   shm::{raw::RawPool, Shm, ShmHandler},
 };
+use std::fs;
 use std::{
   collections::HashMap,
   env,
   process::{Command, Stdio},
-  sync::{Arc, Condvar, Mutex},
+  sync::{Arc, Condvar, Mutex, OnceLock},
 };
-use std::{fs, sync::Once};
 use std::{
   io::{BufRead, BufReader, Write},
   os::unix::net::{UnixListener, UnixStream},
@@ -45,8 +45,7 @@ use std::{
 const DEFAULT_ALPHA: f32 = 0.5;
 const DEFAULT_RADIUS: u32 = 0;
 
-static mut QH: Option<QueueHandle<DimlandData>> = None;
-static QH_INIT: Once = Once::new();
+static QH: OnceLock<QueueHandle<DimlandData>> = OnceLock::new();
 const IS_DEBUG_BUILD: bool = cfg!(debug_assertions);
 
 lazy_static! {
@@ -273,15 +272,7 @@ fn _main() {
 
   let (globals, mut event_queue) = registry_queue_init(&conn).expect("queueless");
 
-  QH_INIT.call_once(|| {
-    let qh = event_queue.handle();
-    unsafe {
-      QH = Some(qh);
-    }
-  });
-
-  #[allow(static_mut_refs)]
-  let qh = unsafe { QH.as_ref().expect("QH not initialized") };
+  let qh = QH.get_or_init(|| event_queue.handle());
 
   let compositor = CompositorState::bind(&globals, &qh).expect("no compositor :sukia:");
   let layer_shell = LayerShell::bind(&globals, &qh).expect("huh?");

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,11 +125,19 @@ fn set_args(args: DimlandArgs) {
   let mut state_ref = STATE.lock().unwrap();
 
   if let Some(output) = &args_ref.output {
-    if let Some(state) = state_ref.get_mut(output) {
-      state.alpha = args_ref.alpha.unwrap_or(DEFAULT_ALPHA);
-      state.radius = args_ref.radius.unwrap_or(DEFAULT_RADIUS);
-    }
+    // Use entry API to insert or update the state for the specified output
+    state_ref
+      .entry(output.clone())
+      .and_modify(|state| {
+        state.alpha = args_ref.alpha.unwrap_or(DEFAULT_ALPHA);
+        state.radius = args_ref.radius.unwrap_or(DEFAULT_RADIUS);
+      })
+      .or_insert(State {
+        alpha: args_ref.alpha.unwrap_or(DEFAULT_ALPHA),
+        radius: args_ref.radius.unwrap_or(DEFAULT_RADIUS),
+      });
   } else {
+    // Update all existing outputs
     for (_output, state) in state_ref.iter_mut() {
       state.alpha = args_ref.alpha.unwrap_or(DEFAULT_ALPHA);
       state.radius = args_ref.radius.unwrap_or(DEFAULT_RADIUS);

--- a/src/main.rs
+++ b/src/main.rs
@@ -423,6 +423,14 @@ impl DimlandData {
     }
   }
 
+  fn get_output_name(&self, output: &WlOutput) -> String {
+    self
+      .output_state
+      .info(output)
+      .and_then(|info| info.name)
+      .unwrap_or_default()
+  }
+
   fn create_view(&self, qh: &QueueHandle<Self>, output: WlOutput) -> DimlandView {
     let layer = self.layer_shell.create_layer_surface(
       qh,
@@ -432,12 +440,7 @@ impl DimlandData {
       Some(&output),
     );
 
-    let output_name = self
-      .output_state
-      .info(&output)
-      .and_then(|info| info.name)
-      .unwrap_or_default();
-
+    let output_name = self.get_output_name(&output);
     let args = get_args();
     let alpha: f32;
     let radius: u32;
@@ -498,21 +501,23 @@ impl DimlandData {
 
     let all_outputs = self.output_state.outputs().collect::<Vec<_>>();
 
-    for view in &mut self.views {
-      let output_name = self
-        .output_state
-        .info(&view.output)
-        .and_then(|info| info.name)
-        .unwrap_or_default();
+    // Collect output names first to avoid borrowing issues
+    let view_outputs: Vec<_> = self
+      .views
+      .iter()
+      .map(|v| (v.output.clone(), self.get_output_name(&v.output)))
+      .collect();
 
+    for (i, (_, output_name)) in view_outputs.iter().enumerate() {
       let mut alpha = 0.0;
       let mut radius = 0;
 
-      if let Some(state) = state_map.get(&output_name) {
+      if let Some(state) = state_map.get(output_name) {
         alpha = state.alpha;
         radius = state.radius;
       }
 
+      let view = &mut self.views[i];
       view.buffer.destroy();
       view.buffer = create_buffer(alpha, radius, self.qh, view.width, view.height, &self.shm);
       view.redraw();
@@ -524,11 +529,7 @@ impl DimlandData {
         continue;
       }
 
-      let output_name = self
-        .output_state
-        .info(&output)
-        .and_then(|info| info.name)
-        .unwrap_or_default();
+      let output_name = self.get_output_name(&output);
 
       if let Some(state) = state_map.get(&output_name) {
         if state.alpha > 0.0 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -68,10 +68,6 @@ struct State {
   radius: u32,
 }
 
-// TODO: populate STATE on first launch
-// DONE: modify STATE when we get new args.
-// TODO: actually use the STATE when making the buffer
-
 #[derive(Debug, Subcommand, Clone)]
 enum DimlandCommands {
   /// Stops the program

--- a/src/main.rs
+++ b/src/main.rs
@@ -62,6 +62,7 @@ lazy_static! {
   static ref STATE: Mutex<HashMap<String, State>> = Mutex::new(HashMap::new());
 }
 
+#[derive(Clone)]
 struct State {
   alpha: f32,
   radius: u32,
@@ -122,7 +123,7 @@ fn set_args(args: DimlandArgs) {
     args_ref.radius = Some(radius);
   }
 
-  args_ref.output = args.output;
+  args_ref.output = args.output.clone();
   args_ref.command = args.command;
   args_ref.detached = args.detached;
 
@@ -283,6 +284,7 @@ fn _main() {
     }
   });
 
+  #[allow(static_mut_refs)]
   let qh = unsafe { QH.as_ref().expect("QH not initialized") };
 
   let compositor = CompositorState::bind(&globals, &qh).expect("no compositor :sukia:");
@@ -454,30 +456,30 @@ impl DimlandData {
       .and_then(|info| info.name)
       .unwrap_or_default();
 
-    let mut alpha = self.alpha;
-    let mut radius = self.radius;
+    let args = get_args();
+    let alpha: f32;
+    let radius: u32;
 
     let mut state_ref = STATE.lock().unwrap();
     if let Some(state) = state_ref.get(&output_name) {
       alpha = state.alpha;
       radius = state.radius;
     } else {
-      state_ref.insert(output_name, State { alpha, radius });
-    }
-
-    if let Some(render) = self.output_state.info(&output).and_then(|info| {
-      let args = get_args();
-      if let Some(output) = args.output {
-        return Some(info.name.expect("no output name found") == output);
+      if let Some(specified_output) = &args.output {
+        if specified_output == &output_name {
+          alpha = args.alpha.unwrap_or(DEFAULT_ALPHA);
+          radius = args.radius.unwrap_or(DEFAULT_RADIUS);
+        } else {
+          alpha = 0.0;
+          radius = 0;
+        }
       } else {
-        return Some(true);
+        alpha = self.alpha;
+        radius = self.radius;
       }
-    }) {
-      if !render {
-        alpha = 0.0;
-        radius = 0;
-      }
+      state_ref.insert(output_name.clone(), State { alpha, radius });
     }
+    drop(state_ref);
 
     let (width, height) = if let Some((width, height)) = self
       .output_state
@@ -508,6 +510,12 @@ impl DimlandData {
   }
 
   fn rerender(&mut self) {
+    let state_ref = STATE.lock().unwrap();
+    let state_map = state_ref.clone();
+    drop(state_ref);
+
+    let all_outputs = self.output_state.outputs().collect::<Vec<_>>();
+
     for view in &mut self.views {
       let output_name = self
         .output_state
@@ -515,21 +523,36 @@ impl DimlandData {
         .and_then(|info| info.name)
         .unwrap_or_default();
 
-      let mut alpha = self.alpha;
-      let mut radius = self.radius;
+      let mut alpha = 0.0;
+      let mut radius = 0;
 
-      let mut state_ref = STATE.lock().unwrap();
-      if let Some(state) = state_ref.get(&output_name) {
+      if let Some(state) = state_map.get(&output_name) {
         alpha = state.alpha;
         radius = state.radius;
-      } else {
-        state_ref.insert(output_name, State { alpha, radius });
       }
 
       view.buffer.destroy();
       view.buffer = create_buffer(alpha, radius, self.qh, view.width, view.height, &self.shm);
-      view.first_configure = true;
-      view.draw(self.qh);
+      view.redraw();
+    }
+
+    for output in all_outputs {
+      let has_view = self.views.iter().any(|v| v.output == output);
+      if has_view {
+        continue;
+      }
+
+      let output_name = self
+        .output_state
+        .info(&output)
+        .and_then(|info| info.name)
+        .unwrap_or_default();
+
+      if let Some(state) = state_map.get(&output_name) {
+        if state.alpha > 0.0 {
+          self.views.push(self.create_view(self.qh, output));
+        }
+      }
     }
   }
 }
@@ -553,11 +576,7 @@ impl DimlandView {
     }
   }
 
-  fn draw(&mut self, _qh: &QueueHandle<DimlandData>) {
-    if !self.first_configure {
-      return;
-    }
-
+  fn redraw(&mut self) {
     self.layer.wl_surface().damage(
       0,
       0,
@@ -582,7 +601,7 @@ impl LayerShellHandler for DimlandData {
   fn configure(
     &mut self,
     _conn: &smithay_client_toolkit::reexports::client::Connection,
-    qh: &QueueHandle<Self>,
+    _qh: &QueueHandle<Self>,
     layer: &LayerSurface,
     configure: smithay_client_toolkit::shell::wlr_layer::LayerSurfaceConfigure,
     _serial: u32,
@@ -598,7 +617,7 @@ impl LayerShellHandler for DimlandData {
       .set_destination(view.width as _, view.height as _);
 
     if view.first_configure {
-      view.draw(qh);
+      view.redraw();
       view.first_configure = false;
     }
   }

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,7 +275,6 @@ fn cleanup() {
 }
 
 fn _main() {
-  let args = get_args();
   let conn = Connection::connect_to_env().expect("where are you running this");
 
   let (globals, mut event_queue) = registry_queue_init(&conn).expect("queueless");
@@ -286,10 +285,7 @@ fn _main() {
   let layer_shell = LayerShell::bind(&globals, &qh).expect("huh?");
   let shm = Shm::bind(&globals, &qh).expect("wl_shm is not available");
 
-  let alpha = args.alpha.unwrap_or(DEFAULT_ALPHA);
-  let radius = args.radius.unwrap_or(DEFAULT_RADIUS);
-
-  let mut data = DimlandData::new(compositor, &globals, &qh, layer_shell, alpha, radius, shm);
+  let mut data = DimlandData::new(compositor, &globals, &qh, layer_shell, shm);
 
   let mut i = 0;
   loop {
@@ -319,8 +315,6 @@ struct DimlandData {
   output_state: OutputState,
   layer_shell: LayerShell,
   viewporter: SimpleGlobal<WpViewporter, 1>,
-  alpha: f32,
-  radius: u32,
   views: Vec<DimlandView>,
   exit: bool,
   shm: Shm,
@@ -413,8 +407,6 @@ impl DimlandData {
     globals: &GlobalList,
     qh: &'static QueueHandle<Self>,
     layer_shell: LayerShell,
-    alpha: f32,
-    radius: u32,
     shm: Shm,
   ) -> Self {
     Self {
@@ -424,8 +416,6 @@ impl DimlandData {
       layer_shell,
       viewporter: SimpleGlobal::<wp_viewporter::WpViewporter, 1>::bind(globals, qh)
         .expect("wp_viewporter not available"),
-      radius,
-      alpha,
       views: Vec::new(),
       exit: false,
       shm,
@@ -466,8 +456,8 @@ impl DimlandData {
           radius = 0;
         }
       } else {
-        alpha = self.alpha;
-        radius = self.radius;
+        alpha = DEFAULT_ALPHA;
+        radius = DEFAULT_RADIUS;
       }
       state_ref.insert(output_name.clone(), State { alpha, radius });
     }


### PR DESCRIPTION
The patch implements per-display dimming state, allowing independent control of brightness for multiple displays.

## Behaviour

When specifying outputs explicitly:

```bash
> dimland -o DP-3 -a 0.8 #Dims only DP-3 to 80% opacity, leaving all other displays unaffected.
> dimland -o DP-1 -a 0.8 #Dims DP-1 to 80% opacity, without modifying DP-3's dimming state or any other display states.
> dimland -o DP-3 -a 0.0 #Resets DP-3 to 0% (no dimming), while DP-1 remains dimmed at 80% and the other displays stay at the default.
```

Each output maintains its own alpha value in a global state map, enabling discrete control over multiple displays.

## Code Changes

### `State` struct (line 65)
Added `#[derive(Clone)]` to allow cloning the state map when re-rendering.

### `fn set_args` (lines 128-146)
Modified to update the `STATE` map when new arguments are received via IPC using the entry API:
- If an output is specified, uses `.entry()` to insert or update that output's state
- This fixes a bug where IPC commands for non-existent outputs were silently ignored
- If no output is specified, all existing outputs are updated to the new values

### `fn create_view` (lines 443-467)
Refactored to query the per-output state from `STATE` instead of using instance fields. When creating a new view:
- Uses new `get_output_name()` to extract output names consistently, refactoring the code.
- If output exists in `STATE`, use its stored alpha/radius
- If output doesn't exist and a specific output is requested, apply alpha/radius only to that output, others get 0
- If no specific output requested, use `DEFAULT_ALPHA`/`DEFAULT_RADIUS` constants

### `fn rerender` (lines 497-540)
Completely rewritten to support dynamic view creation with improved borrow checker safety:
- Clones the entire `STATE` map to avoid holding the lock during rendering
- Pre-collects output names before iterating to avoid mutable/immutable borrow conflicts
- Updates all existing views with their respective state from `STATE`
- Iterates through all available outputs and creates new views for outputs that don't have a view yet but have `alpha > 0.0` in their state

### `DimlandView::redraw`  (lines 563-571)
Simplified by removing the first_configure check. Now it directly marks the entire screen area as needing a refresh, attaches the buffer (the image to display), and commits the changes. The configure handler now only calls this method the first time the window is set up.

### `LayerShellHandler::configure` (lines 602-605)
Modified to only call `redraw()` on the first configure event, preventing unnecessary redraws.

### Removed dead fields from `DimlandData`
Removed unused `alpha` and `radius` instance fields that were never consulted after initialization. The `STATE` map is now the single source of truth for all dimming state.
