### PR TITLE
dim - a bash wrapper that keeps dimland state in ~/.config}/dimland; allows to bind it to the keyboard shortcut keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ Options:
 ## Usage examples:
 
 ```
-dim                      → apply last saved state (global or per-output)
-dim -a 0.2               → set alpha of a transparent black dimming layer
-dim -a 0.4 -o DP-1       → apply alpha to a specific output (e.g. DP-1, HDMI-A-1)
-dim -r 6                 → set radius of rounded screen corners
-dim -s 0.08              → set dimming STEP size (persisted, per-output)
-dim more                 → increase alpha by current STEP size
-dim less                 → decrease alpha by current STEP size
-dim toggle               → toggle (jump) between current and alt-alpha
-dim toggle 0.25          → toggle (jump) to a specific alt-alpha value
-dim status               → show current settings
-dim stop                 → stop dimland
+dim                    → apply last saved state (global or per-output)
+dim -a 0.2             → set alpha of a transparent black dimming layer
+dim -a 0.4 -o DP-1     → apply alpha to a specific output (e.g. DP-1, HDMI-A-1)
+dim -r 6               → set radius of rounded screen corners
+dim -s 0.08            → set dimming STEP size (persisted, per-output)
+dim more               → increase alpha by current STEP size
+dim less               → decrease alpha by current STEP size
+dim toggle             → toggle (jump) between current and alt-alpha
+dim toggle 0.25        → toggle (jump) to a specific alt-alpha value
+dim status             → show current settings
+dim stop               → stop dimland
 ```
 
 ## Usage notes:
@@ -46,7 +46,8 @@ dim stop                 → stop dimland
 - ALPHA PROCESSING and DIMMING TRESHOLD can be adjusted in the ALPHA PROCESSING section
 
 
-# dimland (screen dimmer for Wayland written in Rust)
+
+# dimland (screen dimmer for Wayland)
 
 Dimland is a simple screen dimmer for Wayland. It overlays a transparent black layer on all display outputs, enabling additional brightness reduction, even when the monitor backlight is to 0%. It also includes a feature for drawing opaque screen corners, mimicking a rounded display.
 

--- a/README.md
+++ b/README.md
@@ -26,17 +26,17 @@ Options:
 ## Usage examples:
 
 ```
-dim                    → apply last saved state (global or per-output)
-dim -a 0.2             → set alpha of a transparent black dimming layer
-dim -a 0.4 -o DP-1     → apply alpha to a specific output (e.g. DP-1, HDMI-A-1)
-dim -r 6               → set radius of rounded screen corners
-dim -s 0.08            → set dimming STEP size (persisted, per-output)
-dim more               → increase alpha by current STEP size
-dim less               → decrease alpha by current STEP size
-dim toggle             → toggle (jump) between current and alt-alpha
-dim toggle 0.25        → toggle (jump) to a specific alt-alpha value
-dim status             → show current settings
-dim stop               → stop dimland
+dim                      → apply last saved state (global or per-output)
+dim -a 0.2               → set alpha of a transparent black dimming layer
+dim -a 0.4 -o DP-1       → apply alpha to a specific output (e.g. DP-1, HDMI-A-1)
+dim -r 6                 → set radius of rounded screen corners
+dim -s 0.08              → set dimming STEP size (persisted, per-output)
+dim more                 → increase alpha by current STEP size
+dim less                 → decrease alpha by current STEP size
+dim toggle               → toggle (jump) between current and alt-alpha
+dim toggle 0.25          → toggle (jump) to a specific alt-alpha value
+dim status               → show current settings
+dim stop                 → stop dimland
 ```
 
 ## Usage notes:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,52 @@
-# dimland
+# dim (bash wrapper)
+
+dim - a wrapper for dimland with persistent per-output state saving/loading
+
+```
+Usage: dim [OPTIONS] [COMMAND]
+
+Commands:
+  more         Increase alpha by the current STEP size
+  less         Decrease alpha by the current STEP size
+  toggle       Toggle (jump) between current and alt-alpha
+  toggle 0.25  Toggle (jump) to a specific alt-alpha value
+  status       Show current settings
+  stop         Stop dimland
+
+Options:
+  -a, --alpha <ALPHA>    Transparency level (0.0 transparent, 1.0 opaque)
+      --allow-opaque     Allow alpha to go beyond <THRESHOLD> (90% by default)
+  -r, --radius <RADIUS>  Corner radius (default 6)
+  -s, --step <STEP>      Set dimming STEP size (persisted)
+  -o, --output <OUTPUT>  Output to control (ex. DP-1)
+  -h, --help             Print help
+  -V, --version          Print version
+```
+
+## Usage examples:
+
+```
+dim                      → apply last saved state (global or per-output)
+dim -a 0.2               → set alpha of a transparent black dimming layer
+dim -a 0.4 -o DP-1       → apply alpha to a specific output (e.g. DP-1, HDMI-A-1)
+dim -r 6                 → set radius of rounded screen corners
+dim -s 0.08              → set dimming STEP size (persisted, per-output)
+dim more                 → increase alpha by current STEP size
+dim less                 → decrease alpha by current STEP size
+dim toggle               → toggle (jump) between current and alt-alpha
+dim toggle 0.25          → toggle (jump) to a specific alt-alpha value
+dim status               → show current settings
+dim stop                 → stop dimland
+```
+
+## Usage notes:
+- Automatic --allow-opaque is applied after reaching DIMMING TRESHOLD 5 times in a row
+- CLI args take precedence over STATE file (CLI > STATE > Defaults)
+- User may configure the DEFAULTS to his linking in the DEFAULTS (D_ prefix) section
+- ALPHA PROCESSING and DIMMING TRESHOLD can be adjusted in the ALPHA PROCESSING section
+
+
+# dimland (screen dimmer for Wayland written in Rust)
 
 Dimland is a simple screen dimmer for Wayland. It overlays a transparent black layer on all display outputs, enabling additional brightness reduction, even when the monitor backlight is to 0%. It also includes a feature for drawing opaque screen corners, mimicking a rounded display.
 

--- a/README.md
+++ b/README.md
@@ -6,21 +6,21 @@ dim - a wrapper for dimland with persistent per-output state saving/loading
 Usage: dim [OPTIONS] [COMMAND]
 
 Commands:
-  more         Increase alpha by the current STEP size
-  less         Decrease alpha by the current STEP size
-  toggle       Toggle (jump) between current and alt-alpha
-  toggle 0.25  Toggle (jump) to a specific alt-alpha value
-  status       Show current settings
-  stop         Stop dimland
+  more           Increase alpha by the current STEP size
+  less           Decrease alpha by the current STEP size
+  toggle         Toggle (jump) between current and alt-alpha
+  toggle 0.25    Toggle (jump) to a specific alt-alpha value
+  status         Show current settings
+  stop           Stop dimland
 
 Options:
-  -a, --alpha <ALPHA>    Transparency level (0.0 transparent, 1.0 opaque)
-      --allow-opaque     Allow alpha to go beyond <THRESHOLD> (90% by default)
-  -r, --radius <RADIUS>  Corner radius (default 6)
-  -s, --step <STEP>      Set dimming STEP size (persisted)
-  -o, --output <OUTPUT>  Output to control (ex. DP-1)
-  -h, --help             Print help
-  -V, --version          Print version
+  -a, --alpha <ALPHA>      Transparency level (0.0 transparent, 1.0 opaque)
+      --allow-opaque       Allow alpha to go beyond THRESHOLD (90% by default)
+  -r, --radius <RADIUS>    Corner radius (default 6)
+  -s, --step <STEP>        Set dimming STEP size (persisted)
+  -o, --output <OUTPUT>    Output to control (ex. DP-1)
+  -h, --help               Print help
+  -V, --version            Print version
 ```
 
 ## Usage examples:
@@ -40,10 +40,10 @@ dim stop               → stop dimland
 ```
 
 ## Usage notes:
-- Automatic --allow-opaque is applied after reaching DIMMING TRESHOLD 5 times in a row
-- CLI args take precedence over STATE file (CLI > STATE > Defaults)
-- User may configure the DEFAULTS to his linking in the DEFAULTS (D_ prefix) section
-- ALPHA PROCESSING and DIMMING TRESHOLD can be adjusted in the ALPHA PROCESSING section
+- Automatic `--allow-opaque` is applied after reaching `DIMMING TRESHOLD` 5 times in a row
+- `CLI args` take precedence over `STATE file` (`CLI` > `STATE` > `DEFAULTS`)
+- User may configure the `DEFAULTS` to his linking in the `DEFAULTS (D_ prefix)` section
+- `ALPHA PROCESSING` and `DIMMING TRESHOLD` can be adjusted in the `ALPHA PROCESSING` section
 
 
 

--- a/README.md
+++ b/README.md
@@ -1,52 +1,3 @@
-# dim (bash wrapper)
-
-dim - a wrapper for dimland with persistent per-output state saving/loading
-
-```
-Usage: dim [OPTIONS] [COMMAND]
-
-Commands:
-  more           Increase alpha by the current STEP size
-  less           Decrease alpha by the current STEP size
-  toggle         Toggle (jump) between current and alt-alpha
-  toggle 0.25    Toggle (jump) to a specific alt-alpha value
-  status         Show current settings
-  stop           Stop dimland
-
-Options:
-  -a, --alpha <ALPHA>      Transparency level (0.0 transparent, 1.0 opaque)
-      --allow-opaque       Allow alpha to go beyond THRESHOLD (90% by default)
-  -r, --radius <RADIUS>    Corner radius (default 6)
-  -s, --step <STEP>        Set dimming STEP size (persisted)
-  -o, --output <OUTPUT>    Output to control (ex. DP-1)
-  -h, --help               Print help
-  -V, --version            Print version
-```
-
-## Usage examples:
-
-```
-dim                      → apply last saved state (global or per-output)
-dim -a 0.2               → set alpha of a transparent black dimming layer
-dim -a 0.4 -o DP-1       → apply alpha to a specific output (e.g. DP-1, HDMI-A-1)
-dim -r 6                 → set radius of rounded screen corners
-dim -s 0.08              → set dimming STEP size (persisted, per-output)
-dim more                 → increase alpha by current STEP size
-dim less                 → decrease alpha by current STEP size
-dim toggle               → toggle (jump) between current and alt-alpha
-dim toggle 0.25          → toggle (jump) to a specific alt-alpha value
-dim status               → show current settings
-dim stop                 → stop dimland
-```
-
-## Usage notes:
-- Automatic `--allow-opaque` is applied after reaching `DIMMING TRESHOLD` 5 times in a row
-- `CLI args` take precedence over `STATE file` (`CLI` > `STATE` > `DEFAULTS`)
-- User may configure the `DEFAULTS` to his linking in the `DEFAULTS (D_ prefix)` section
-- `ALPHA PROCESSING` and `DIMMING TRESHOLD` can be adjusted in the `ALPHA PROCESSING` section
-
-
-
 # dimland (screen dimmer for Wayland)
 
 Dimland is a simple screen dimmer for Wayland. It overlays a transparent black layer on all display outputs, enabling additional brightness reduction, even when the monitor backlight is to 0%. It also includes a feature for drawing opaque screen corners, mimicking a rounded display.
@@ -122,6 +73,54 @@ Options:
   -h, --help             Print help
   -V, --version          Print version
 ```
+
+## dim (bash wrapper)
+
+dim - a wrapper for dimland with persistent per-output state saving/loading
+
+```
+Usage: dim [OPTIONS] [COMMAND]
+
+Commands:
+  more           Increase alpha by the current STEP size
+  less           Decrease alpha by the current STEP size
+  toggle         Toggle (jump) between current and alt-alpha
+  toggle 0.25    Toggle (jump) to a specific alt-alpha value
+  status         Show current settings
+  stop           Stop dimland
+
+Options:
+  -a, --alpha <ALPHA>      Transparency level (0.0 transparent, 1.0 opaque)
+      --allow-opaque       Allow alpha to go beyond THRESHOLD (90% by default)
+  -r, --radius <RADIUS>    Corner radius (default 6)
+  -s, --step <STEP>        Set dimming STEP size (persisted)
+  -o, --output <OUTPUT>    Output to control (ex. DP-1)
+  -h, --help               Print help
+  -V, --version            Print version
+```
+
+## Usage examples:
+
+```
+dim                      → apply last saved state (global or per-output)
+dim -a 0.2               → set alpha of a transparent black dimming layer
+dim -a 0.4 -o DP-1       → apply alpha to a specific output (e.g. DP-1, HDMI-A-1)
+dim -r 6                 → set radius of rounded screen corners
+dim -s 0.08              → set dimming STEP size (persisted, per-output)
+dim more                 → increase alpha by current STEP size
+dim less                 → decrease alpha by current STEP size
+dim toggle               → toggle (jump) between current and alt-alpha
+dim toggle 0.25          → toggle (jump) to a specific alt-alpha value
+dim status               → show current settings
+dim stop                 → stop dimland
+```
+
+## Usage Notes
+
+- Automatic `--allow-opaque` is applied after reaching `DIMMING TRESHOLD` 5 times in a row
+- `CLI args` take precedence over `STATE file` (`CLI` > `STATE` > `DEFAULTS`)
+- User may configure the `DEFAULTS` to his linking in the `DEFAULTS (D_ prefix)` section
+- `ALPHA PROCESSING` and `DIMMING TRESHOLD` can be adjusted in the `ALPHA PROCESSING` section
 
 [Nix package manager]: https://nixos.org/download/
 [Rust]: https://ww.rust-lang.org/

--- a/src/dim
+++ b/src/dim
@@ -1,0 +1,229 @@
+#!/usr/bin/env bash
+# dim - a wrapper for dimland with persistent per-output state saving/loading
+#
+# Usage examples:
+#   dim                          → apply last saved state (global or per-output)
+#   dim -a 0.2                   → set alpha of a transparent black dimming layer
+#   dim -a 0.4 -o DP-1           → apply alpha to a specific output (e.g. DP-1, HDMI-A-1)
+#   dim -r 6                     → set radius of rounded screen corners
+#   dim -s 0.08                  → set dimming STEP size (persisted)
+#   dim more                     → increase alpha by current STEP size
+#   dim less                     → decrease alpha by current STEP size
+#   dim toggle                   → toggle (jump) between current and alt-alpha
+#   dim toggle 0.25              → toggle (jump) to a specific alt-alpha value
+#   dim status                   → show current settings
+#   dim stop                     → stop dimland
+
+
+# ==================== CMD LINE ARGS (C_ prefix) ====================
+
+C_ALPHA=""
+C_OUTPUT=""
+C_RADIUS=""
+C_STEP=""
+
+
+# ==================== DEFAULTS (D_ prefix) ====================
+
+D_ALPHA=0.25
+D_ALPHA_ALT=0.45
+D_OPAQUE_COUNTER=0
+D_RADIUS=6
+D_STEP=0.05
+
+
+# ==================== OTHER VARIABLES ====================
+
+ALPHA=""
+ALPHA_ALT=""
+OPAQUE_COUNTER=""
+RADIUS=""
+STEP=""
+
+ALLOW_OPAQUE=""
+COMMAND=""
+OUTPUT=""
+TOGGLE_TO=""
+
+
+# ==================== PARSE ARGUMENTS ====================
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -o|--output)
+            C_OUTPUT="$2"
+            shift 2
+            ;;
+        -s|--step)
+            C_STEP="$2"
+            shift 2
+            ;;
+        more|less|toggle|stop|status)
+            COMMAND="$1"
+            if [[ "$COMMAND" == "toggle" && $# -gt 1 && "$2" =~ ^[0-9]*\.?[0-9]+$ ]]; then
+                TOGGLE_TO="$2"
+                shift
+            fi
+            shift
+            ;;
+        -a|--alpha)
+            C_ALPHA="$2"
+            shift 2
+            ;;
+        -r|--radius)
+            C_RADIUS="$2"
+            shift 2
+            ;;
+        --allow-opaque)
+            ALLOW_OPAQUE="--allow-opaque"
+            shift
+            ;;
+        -h|--help|-V|--version)
+            dimland "$@"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+
+# ==================== STEP SIZE VALIDATION ====================
+
+if [[ -n "$C_STEP" ]]; then
+    if ! [[ "$C_STEP" =~ ^[0-9]*\.?[0-9]+$ ]] || (( $(awk "BEGIN {print ($C_STEP <= 0 || $C_STEP > 0.45)}") )); then
+        echo "Error: Invalid step size '$C_STEP'. Must be a positive number ≤ 0.45 (e.g. 0.05, 0.1, 0.02)" >&2
+        exit 1
+    fi
+fi
+
+
+# ==================== DIMLAND STATE LOADING ====================
+
+STATE_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/dimland"
+mkdir -p "$STATE_DIR"
+
+if [[ -n "$C_OUTPUT" ]]; then
+    STATE_FILE="$STATE_DIR/state_${C_OUTPUT//[^a-zA-Z0-9]/_}"
+    OUTPUT="$C_OUTPUT"
+else
+    STATE_FILE="$STATE_DIR/state"
+fi
+
+# Load saved state (if exists)
+if [[ -f "$STATE_FILE" ]]; then
+    # shellcheck source=/dev/null
+    source "$STATE_FILE"
+fi
+
+
+# ==================== VARIABLE PRIORITIES ====================
+
+# CLI args take precedence over STATE file (CLI > STATE > Defaults)
+ALPHA="${C_ALPHA:-${ALPHA:-$D_ALPHA}}"
+ALPHA_ALT="${ALPHA_ALT:-${D_ALPHA_ALT}}"
+OPAQUE_COUNTER="${OPAQUE_COUNTER:-$D_OPAQUE_COUNTER}"
+RADIUS="${C_RADIUS:-${RADIUS:-$D_RADIUS}}"
+STEP="${C_STEP:-${STEP:-$D_STEP}}"
+
+
+# ==================== COMMAND HANDLING ====================
+
+case "${COMMAND:-}" in
+    stop)
+        dimland stop
+        exit 0
+        ;;
+
+    status)
+        echo "dim status:"
+        echo "  Output       : ${OUTPUT:-global}"
+        echo "  Alpha        : $ALPHA"
+        echo "  Alt Alpha    : ${ALPHA_ALT:-none}"
+        echo "  Radius       : $RADIUS"
+        echo "  Step         : $STEP"
+        echo "  Opaque count : $OPAQUE_COUNTER"
+        [[ -n "$ALLOW_OPAQUE" ]] && echo "  Allow opaque : enabled"
+        exit 0
+        ;;
+
+    more)
+        ALPHA=$(awk "BEGIN {printf \"%.2f\", $ALPHA + $STEP}")
+        ;;
+
+    less)
+        ALPHA=$(awk "BEGIN {printf \"%.2f\", $ALPHA - $STEP}")
+        if (( $(awk "BEGIN {print ($ALPHA < 0)}") )); then
+            dimland stop
+            echo "Alpha would be negative → stopped dimland"
+            exit 0
+        fi
+        ;;
+
+    toggle)
+        if [[ -n "$TOGGLE_TO" ]]; then
+            ALPHA_ALT="$ALPHA"
+            ALPHA="$TOGGLE_TO"
+        elif [[ -n "$ALPHA_ALT" && "$ALPHA_ALT" != "$ALPHA" ]]; then
+            TEMP="$ALPHA"
+            ALPHA="$ALPHA_ALT"
+            ALPHA_ALT="$TEMP"
+        else
+            echo "No alt-alpha to toggle with. Use 'dim toggle <value>' first." >&2
+            exit 1
+        fi
+        ;;
+esac
+
+
+# ==================== ALPHA PROCESSING ====================
+
+# DIMMING TRESHOLD (0.70 == 70% dark)
+THRESHOLD=0.90
+# THRESHOLD=$(awk "BEGIN {printf \"%.2f\", 1 - $STEP}")
+
+# Automatic --allow-opaque after reaching threshold X times in a row
+if (( $(awk "BEGIN {print ($ALPHA >= $THRESHOLD)}") )); then
+    ((OPAQUE_COUNTER++))
+    if [[ $OPAQUE_COUNTER -gt 5 ]]; then
+        ALLOW_OPAQUE="--allow-opaque"
+    fi
+else
+    OPAQUE_COUNTER=0
+fi
+
+# Now apply final alpha limits
+if [[ -n "$ALLOW_OPAQUE" ]]; then
+    # With --allow-opaque we can go up to 1.0
+    if (( $(awk "BEGIN {print ($ALPHA > 1)}") )); then
+        ALPHA=1.0
+    fi
+else
+    # Without --allow-opaque we cap ALPHA at DIMMING TRESHOLD
+    if (( $(awk "BEGIN {print ($ALPHA > $THRESHOLD)}") )); then
+        ALPHA="$THRESHOLD"
+    fi
+fi
+
+
+# ==================== DIMLAND EXEC ====================
+
+CMD=(dimland)
+CMD+=(--alpha "$ALPHA")
+CMD+=(--radius "$RADIUS")
+[[ -n "$ALLOW_OPAQUE" ]] && CMD+=("$ALLOW_OPAQUE")
+[[ -n "$OUTPUT" ]] && CMD+=(--output "$OUTPUT")
+
+"${CMD[@]}"
+
+
+# ==================== STATE SAVING ====================
+
+{
+    declare -p ALPHA ALPHA_ALT OPAQUE_COUNTER RADIUS STEP 2>/dev/null || true
+} > "$STATE_FILE"
+
+
+


### PR DESCRIPTION
I've created this dimland wrapper after installing dimland on my SteamOS and not being able to bind it to the keyboard. It solves feature requested in https://github.com/keifufu/dimland/issues/3 and was tested for a few days in both CLI and via keyboard shortcuts.

I also extended README.md with usage examples. Feel free to modify it as you please or let me know what needs to be done. Below is a screenshot from KDE System Settings:

<img width="1801" height="585" alt="sample dim config in kde system settings" src="https://github.com/user-attachments/assets/b90ff09a-1908-4ade-87d5-a5d25be6bdbc" />

Cheers!